### PR TITLE
enable cargo run to dfu

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,5 +1,5 @@
 [target.thumbv6m-none-eabi]
-runner = 'arm-none-eabi-gdb'
+runner = ["./upload.sh"]
 rustflags = [
   "-C", "opt-level=z",
   "-C", "link-arg=-Tlink.x",

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To build embedded programs using this template you'll need:
 - `rust-std` components (pre-compiled `core` crate) for the ARM Cortex-M
   targets. Run:
 ``` console
-$ rustup target add thumbv7m-none-eabi
+$ rustup target add thumbv6m-none-eabi
 ```
 
 - llvm-tools-preview for `llvm-objcopy` to turn the elf into a binary for uploading. Run:
@@ -39,7 +39,6 @@ usage
 ---
 
 ```
-cd hal
 cargo run --example touch_button --release
 
 ```

--- a/README.md
+++ b/README.md
@@ -13,6 +13,36 @@ work in progress
 - [ ] USB
 - [ ] AES
 
+
+dependencies
+---
+
+To build embedded programs using this template you'll need:
+
+- Rust stable, ie 1.31 or a newer toolchain.
+
+- `rust-std` components (pre-compiled `core` crate) for the ARM Cortex-M
+  targets. Run:
+``` console
+$ rustup target add thumbv7m-none-eabi
+```
+
+- llvm-tools-preview for `llvm-objcopy` to turn the elf into a binary for uploading. Run:
+``` console
+$ rustup component add llvm-tools-preview
+```
+
+- The [dfu-util](https://tomu.im/update#installing-dfu-util)
+
+
+usage
+---
+
+```
+cd hal
+cargo run --example touch_button --release
+
+```
 toboot config
 ---
 

--- a/upload.sh
+++ b/upload.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# ideally in the future this script is deprecated for a cargo tools bin method
+# https://matklad.github.io/2018/01/03/make-your-own-make.html
+# but were waiting on the ability to run std build scripts in a no_std project
+# https://github.com/rust-embedded/wg/issues/256#issuecomment-438483578
+
+# alternatively cargo-make is an option but thats difficult to run from a runner
+# and maintain cross platform support, so I offer this sugar for *nix users only
+
+# but in the mean time this hardcodes the llvm find from cargo-binutils
+# https://github.com/rust-embedded/cargo-binutils
+
+set -x
+set -e
+
+$(find $(rustc --print sysroot) -name llvm-objcopy) -O binary "$@" "$@".bin
+cp "$@".bin "$@".dfu
+dfu-suffix -v 1209 -p 70b1 -a "$@".dfu
+dfu-util --download "$@".dfu


### PR DESCRIPTION
So we cant actually gdb as we dont have a debugger. So I decided to hook it up to the upload script instead and I really like this. you get to just run `cargo run --example touch_button --release` and itll upload

Ive been desperately trying to not make it a bash script, but as you can see in the notes there I just keep hitting walls so for now.. its sugar only for nix users.. but `arm-none-eabi-gdb` wasnt doing anything before anyway so seems fine to me

Thoughts?
