### PR TITLE
update for 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,9 +2,10 @@
 name = "tomu-hal"
 version = "0.1.0"
 authors = ["Nurahmadie <nurahmadie@gmail.com>"]
+edition = "2018"
 
 [dependencies]
-efm32hg309f64-pac = { git = "https://github.com/jacobrosenthal/efm32hg309f64-pac", features = ["rt"] }
+efm32 = { git = "https://github.com/jacobrosenthal/efm32hg309f64-pac", features = ["rt"], package="efm32hg309f64-pac" }
 tomu-hal-macros = { path = "macros", optional = true }
 embedded-hal = { version = "0.2.1", features = ["unproven"] }
 

--- a/examples/blink.rs
+++ b/examples/blink.rs
@@ -1,9 +1,7 @@
 #![no_std]
 #![no_main]
 
-extern crate cortex_m_rt;
 extern crate panic_halt;
-extern crate tomu_hal;
 
 use cortex_m_rt::entry;
 use tomu_hal::{led::LedTrait, peripherals};
@@ -24,7 +22,8 @@ fn main() -> ! {
         } else if counter == 200000 {
             p.led.green().off();
             p.led.red().off();
-        } if counter == 100000 {
+        }
+        if counter == 100000 {
             p.led.green().off();
             p.led.red().on();
         }

--- a/examples/toboot_config.rs
+++ b/examples/toboot_config.rs
@@ -1,16 +1,12 @@
 #![no_std]
 #![no_main]
 
-extern crate cortex_m_rt;
-extern crate embedded_hal;
 extern crate panic_halt;
-extern crate tomu_hal;
 
 // For non-examples (i.e. an actual crate)
 // tomu_hal_macros don't need to be explicitly
 // imported, tomu_hal can be built with `toboot-custom-config` feature
 // which will import and reexport toboot_config automatically
-extern crate tomu_hal_macros;
 use tomu_hal_macros::toboot_config;
 
 use cortex_m_rt::entry;

--- a/examples/touch_button.rs
+++ b/examples/touch_button.rs
@@ -1,10 +1,7 @@
 #![no_std]
 #![no_main]
 
-extern crate cortex_m_rt;
-extern crate embedded_hal;
 extern crate panic_halt;
-extern crate tomu_hal;
 
 use cortex_m_rt::entry;
 use tomu_hal::{led::LedTrait, peripherals};

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,15 +1,11 @@
 #![feature(proc_macro_diagnostic)]
 
 extern crate proc_macro;
-extern crate proc_macro2;
-extern crate quote;
-extern crate syn;
 
 use proc_macro2::Span;
 use quote::quote;
-use syn::parse;
 use syn::{
-    parse::{Parse, ParseStream, Result},
+    parse::{self, Parse, ParseStream, Result},
     parse_macro_input,
     spanned::Spanned,
     Expr, ExprArray, Ident, LitBool, LitInt, Token,

--- a/src/capacitive.rs
+++ b/src/capacitive.rs
@@ -1,8 +1,8 @@
-use embedded_hal::digital::{InputPin, OutputPin};
-use gpio::{
+use crate::gpio::{
     pin::{C0, C1, E12, E13},
     InputPullDown, OpenDrain, GPIO,
 };
+use embedded_hal::digital::{InputPin, OutputPin};
 
 pub struct Button<Sink, Source> {
     sink: Sink,

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -25,7 +25,7 @@
 //!
 //! ```
 
-use efm32;
+use crate::efm32;
 
 /// Disable Input/Output no pullup.
 pub struct Disabled;

--- a/src/led.rs
+++ b/src/led.rs
@@ -1,8 +1,8 @@
-use embedded_hal::digital::OutputPin;
-use gpio::{
+use crate::gpio::{
     pin::{A0, B7},
     OpenDrain, GPIO,
 };
+use embedded_hal::digital::OutputPin;
 
 /// LED struct stores all leds available
 /// in tomu board.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,9 @@
 #![no_std]
 
-extern crate efm32hg309f64_pac as efm32;
-extern crate embedded_hal;
+pub use efm32;
 
-#[cfg(feature = "toboot-custom-config")]
-extern crate tomu_hal_macros;
+#[cfg(feature = "rt")]
+pub use crate::efm32::interrupt;
 
 pub mod toboot;
 

--- a/src/peripherals.rs
+++ b/src/peripherals.rs
@@ -1,7 +1,7 @@
-use capacitive;
-use efm32;
-use gpio;
-use led;
+use crate::capacitive;
+use crate::efm32;
+use crate::gpio;
+use crate::led;
 
 /// Watchdog peripheral for tomu board.
 pub struct Watchdog;


### PR DESCRIPTION
Closes #16

Im leaving 
```
extern crate panic_halt;
```

because I think this is objectively worse
```
#[allow(unused_imports)]
use panic_halt;
```