### PR TITLE
Support Rust stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,6 @@ rust:
   - nightly
 
 matrix:
-  allow_failures:
-    - rust: stable
-    - rust: beta
   fast_finish: true
 
 cache: cargo

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 efm32 = { git = "https://github.com/jacobrosenthal/efm32hg309f64-pac", features = ["rt"], package="efm32hg309f64-pac" }
 tomu-hal-macros = { path = "macros", optional = true }
-embedded-hal = { version = "0.2.1", features = ["unproven"] }
+embedded-hal = { version = "0.2.2", features = ["unproven"] }
 
 # We don't have direct dependencies to this,
 # but will need this to build examples

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ toboot_config! {
 }
 ```
 
-![warns](https://f4.fudan.ch/shx/putty_(3)_2018-12-02_04-08-41.png)
+![warns](https://f4.fudan.ch/shx/putty_(3)_2019-01-28_13-43-45.png)
 
 Full config as the following:
 ```rust

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -8,12 +8,12 @@ edition = "2018"
 proc-macro = true
 
 [dependencies]
-quote = "0.6.10"
-proc-macro2 = { version = "0.4.24", features = ["nightly"] }
+quote = "0.6.11"
+proc-macro2 = "0.4.26"
 
 [dependencies.syn]
 features = ["extra-traits", "full"]
-version = "0.15.13"
+version = "0.15.26"
 
 [dev-dependencies]
 tomu-hal = { path = ".." }

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(proc_macro_diagnostic)]
-
 extern crate proc_macro;
 
 use proc_macro2::Span;
@@ -198,13 +196,17 @@ pub fn toboot_config(input: crate::proc_macro::TokenStream) -> crate::proc_macro
     let erase_mask_lo_val = parsed_config.erase_mask_lo_val();
     let erase_mask_hi_val = parsed_config.erase_mask_hi_val();
 
+    // FIXME: revert this back to using proc_macro's `warning` when it's stabilized
     if lock_val == TOBOOT_LOCK_ENTRY_MAGIC {
-        parsed_config
-            .lock_entry
-            .span()
-            .unstable()
-            .warning("*CAUTION* this will lock you from entering bootloader")
-            .emit();
+        eprintln!(r#"
+***************** CAUTION! *******************
+* Setting toboot lock entry to `true` will   *
+* _LOCK_ you out from entering bootloader.   *
+* Unless you know what you're doing, you may *
+* want to set `lock_entry` to `false` or     *
+* remove the setting altogether.             *
+**********************************************
+"#);
     }
 
     let result = quote! {


### PR DESCRIPTION
Add support for rust stable,
need to remove warning invocation as it depends on unstable `Diagnostic` API.
Also replaced spanned warning with poorman's _caution_ printings.
And updated some dependencies.

fix #14 