### PR TITLE
WIP gpio split

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,0 @@
-nightly

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,1 @@
+nightly

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -25,12 +25,16 @@
 //!
 //! ```
 
-use core::marker::PhantomData;
 use crate::efm32;
 use crate::efm32::{CMU, GPIO};
-use embedded_hal::digital::{OutputPin, ToggleableOutputPin};
+use core::marker::PhantomData;
+use embedded_hal::digital::{InputPin, OutputPin};
+
+#[cfg(feature = "unproven")]
+use embedded_hal::digital::ToggleableOutputPin;
 
 pub trait OutputMode {}
+pub trait InputMode {}
 
 /// Disable Input/Output no pullup.
 pub struct Disabled;
@@ -40,75 +44,91 @@ pub struct DisabledPullUp;
 
 /// Enable Input without glitch filter.
 pub struct Input;
+impl InputMode for Input {}
 
 /// Enable Input with glitch filter.
 pub struct InputWithFilter;
+impl InputMode for InputWithFilter {}
 
 /// Enable Input with pull-down resistor (without glitch filter).
 pub struct InputPullDown;
+impl InputMode for InputPullDown {}
 
 /// Enable Input with pull-up resistor (without glitch filter).
 pub struct InputPullUp;
+impl InputMode for InputPullUp {}
 
 /// Enable Input with pull-down resistor and glitch filter.
 pub struct InputPullDownWithFilter;
+impl InputMode for InputPullDownWithFilter {}
 
 /// Enable Input with pull-up resistor and glitch filter.
 pub struct InputPullUpWithFilter;
+impl InputMode for InputPullUpWithFilter {}
 
 /// Enable Input and Output in push-pull mode.
 pub struct PushPull;
+impl OutputMode for PushPull {}
 
 /// Enable Input and Output in push-pull mode and enable current drive.
 pub struct PushPullDrive;
+impl OutputMode for PushPullDrive {}
 
 /// Enable Input and Output in open-source mode.
 pub struct WiredOr;
 pub type OpenSource = WiredOr;
+impl OutputMode for OpenSource {}
 
 /// Enable Input and Output in open-source mode and pull-down resistor.
 pub struct WiredOrPullDown;
 pub type OpenSourcePullDown = WiredOrPullDown;
+impl OutputMode for OpenSourcePullDown {}
 
 /// Enable Input and Output in open-drain mode.
 pub struct WiredAnd;
 pub type OpenDrain = WiredAnd;
-impl OutputMode for WiredAnd {}
+impl OutputMode for OpenDrain {}
 
 /// Enable Input and Output in open-drain mode with glitch filter for input.
 pub struct WiredAndWithFilter;
 pub type OpenDrainWithFilter = WiredAndWithFilter;
+impl OutputMode for OpenDrainWithFilter {}
 
 /// Enable Input and Output in open-drain mode and pull-up resistor without
 /// glitch filter for input.
 pub struct WiredAndPullUp;
 pub type OpenDrainPullUp = WiredAndPullUp;
+impl OutputMode for OpenDrainPullUp {}
 
 /// Enable Input and Output in open-drain mode and pull-up resistor with
 /// glitch filter for input.
 pub struct WiredAndPullUpWithFilter;
 pub type OpenDrainPullUpWithFilter = WiredAndPullUpWithFilter;
+impl OutputMode for OpenDrainPullUpWithFilter {}
 
 /// Enable Input and Output in open-drain mode and enable current drive without
 /// glitch filter for input.
 pub struct WiredAndDrive;
 pub type OpenDrainDrive = WiredAndDrive;
+impl OutputMode for OpenDrainDrive {}
 
 /// Enable Input and Output in open-drain mode and enable current drive with
 /// glitch filter for input.
 pub struct WiredAndDriveWithFilter;
 pub type OpenDrainDriveWithFilter = WiredAndDriveWithFilter;
+impl OutputMode for OpenDrainDriveWithFilter {}
 
 /// Enable Input and Output in open-drain mode and pull-up resister and also
 /// enable current drive without glitch filter for input.
 pub struct WiredAndDrivePullUp;
 pub type OpenDrainDrivePullUp = WiredAndDrivePullUp;
+impl OutputMode for OpenDrainDrivePullUp {}
 
 /// Enable Input and Output in open-drain mode and pull-up resistor and also
 /// enable current drive with glitch filter for input.
 pub struct WiredAndDrivePullUpWithFilter;
 pub type OpenDrainDrivePullUpWithFilter = WiredAndDrivePullUpWithFilter;
-
+impl OutputMode for OpenDrainDrivePullUpWithFilter {}
 
 /// Extension trait to split a GPIO peripheral in independent pins and registers
 pub trait GpioExt {
@@ -119,12 +139,13 @@ pub trait GpioExt {
     fn split(self, cmu: &mut CMU) -> Self::Parts;
 }
 
-macro_rules! gpio_pin { 
-    ($PXi:ident, $i:expr, $mode: ident, $modegroup: ident, $outset:ident, $outclr: ident, $outtgl: ident) => {
+macro_rules! gpio_pin {
+    ($PXi:ident, $i:expr, $mode: ident, $modegroup: ident,
+        $outset:ident, $outclr: ident, $outtgl:ident, $in:ident) => {
         pub struct $PXi<MODE> {
             _mode: PhantomData<MODE>,
         }
-        
+
         impl<MODE: OutputMode> OutputPin for $PXi<MODE> {
             fn set_high(&mut self) {
                 // NOTE(unsafe) atomic write to a stateless register
@@ -133,18 +154,138 @@ macro_rules! gpio_pin {
 
             fn set_low(&mut self) {
                 // NOTE(unsafe) atomic write to a stateless register
-               unsafe { (*efm32::GPIO::ptr()).$outclr.write(|w| w.bits(1 << $i)) };
+                unsafe { (*efm32::GPIO::ptr()).$outclr.write(|w| w.bits(1 << $i)) };
             }
         }
 
+        #[cfg(feature = "unproven")]
         impl<MODE: OutputMode> ToggleableOutputPin for $PXi<MODE> {
             fn toggle(&mut self) {
                 unsafe { (*efm32::GPIO::ptr()).$outtgl.write(|w| w.bits(1 << $i)) };
             }
         }
 
+        impl<MODE: InputMode> InputPin for $PXi<MODE> {
+            fn is_high(&self) -> bool {
+                let pos = 1 << $i;
+                unsafe { ((*efm32::GPIO::ptr()).$in.read().bits() & pos) == pos }
+            }
+
+            fn is_low(&self) -> bool {
+                !self.is_high()
+            }
+        }
+
         impl<MODE> $PXi<MODE> {
-            pub fn into_open_drain(self) -> $PXi<OpenDrain> {
+            pub fn into_disabled(self) -> $PXi<Disabled> {
+                unsafe {
+                    (*efm32::GPIO::ptr())
+                        .$modegroup
+                        .modify(|_, w| w.$mode().disabled())
+                };
+                $PXi { _mode: PhantomData }
+            }
+
+            pub fn into_disabled_pull_up(self) -> $PXi<DisabledPullUp> {
+                unsafe {
+                    (*efm32::GPIO::ptr())
+                        .$modegroup
+                        .modify(|_, w| w.$mode().disabled())
+                };
+                $PXi { _mode: PhantomData }
+            }
+
+            pub fn into_input(self) -> $PXi<Input> {
+                unsafe {
+                    (*efm32::GPIO::ptr())
+                        .$modegroup
+                        .modify(|_, w| w.$mode().input())
+                };
+                $PXi { _mode: PhantomData }
+            }
+
+            pub fn into_input_with_filter(self) -> $PXi<InputWithFilter> {
+                unsafe {
+                    (*efm32::GPIO::ptr())
+                        .$modegroup
+                        .modify(|_, w| w.$mode().input())
+                };
+                $PXi { _mode: PhantomData }
+            }
+
+            pub fn into_input_pull_down(self) -> $PXi<InputPullDown> {
+                unsafe {
+                    (*efm32::GPIO::ptr())
+                        .$modegroup
+                        .modify(|_, w| w.$mode().inputpull())
+                };
+                $PXi { _mode: PhantomData }
+            }
+
+            pub fn into_input_pull_up(self) -> $PXi<InputPullUp> {
+                unsafe {
+                    (*efm32::GPIO::ptr())
+                        .$modegroup
+                        .modify(|_, w| w.$mode().inputpull())
+                };
+                $PXi { _mode: PhantomData }
+            }
+
+            pub fn into_input_pull_down_with_filter(self) -> $PXi<InputPullDownWithFilter> {
+                unsafe {
+                    (*efm32::GPIO::ptr())
+                        .$modegroup
+                        .modify(|_, w| w.$mode().inputpullfilter())
+                };
+                $PXi { _mode: PhantomData }
+            }
+
+            pub fn into_input_pull_up_with_filter(self) -> $PXi<InputPullUpWithFilter> {
+                unsafe {
+                    (*efm32::GPIO::ptr())
+                        .$modegroup
+                        .modify(|_, w| w.$mode().inputpullfilter())
+                };
+                $PXi { _mode: PhantomData }
+            }
+
+            pub fn into_output_push_pull(self) -> $PXi<PushPull> {
+                unsafe {
+                    (*efm32::GPIO::ptr())
+                        .$modegroup
+                        .modify(|_, w| w.$mode().pushpull())
+                };
+                $PXi { _mode: PhantomData }
+            }
+
+            pub fn into_output_push_pull_drive(self) -> $PXi<PushPullDrive> {
+                unsafe {
+                    (*efm32::GPIO::ptr())
+                        .$modegroup
+                        .modify(|_, w| w.$mode().pushpulldrive())
+                };
+                $PXi { _mode: PhantomData }
+            }
+
+            pub fn into_output_open_source(self) -> $PXi<WiredOr> {
+                unsafe {
+                    (*efm32::GPIO::ptr())
+                        .$modegroup
+                        .modify(|_, w| w.$mode().wiredor())
+                };
+                $PXi { _mode: PhantomData }
+            }
+
+            pub fn into_output_open_source_pull_down(self) -> $PXi<WiredOrPullDown> {
+                unsafe {
+                    (*efm32::GPIO::ptr())
+                        .$modegroup
+                        .modify(|_, w| w.$mode().wiredorpulldown())
+                };
+                $PXi { _mode: PhantomData }
+            }
+
+            pub fn into_output_open_drain(self) -> $PXi<WiredAnd> {
                 unsafe {
                     (*efm32::GPIO::ptr())
                         .$modegroup
@@ -152,25 +293,92 @@ macro_rules! gpio_pin {
                 };
                 $PXi { _mode: PhantomData }
             }
+
+            pub fn into_output_open_drain_with_filter(self) -> $PXi<WiredAndWithFilter> {
+                unsafe {
+                    (*efm32::GPIO::ptr())
+                        .$modegroup
+                        .modify(|_, w| w.$mode().wiredandfilter())
+                };
+                $PXi { _mode: PhantomData }
+            }
+
+            pub fn into_output_open_drain_pull_up(self) -> $PXi<WiredAndPullUp> {
+                unsafe {
+                    (*efm32::GPIO::ptr())
+                        .$modegroup
+                        .modify(|_, w| w.$mode().wiredandpullup())
+                };
+                $PXi { _mode: PhantomData }
+            }
+
+            pub fn into_output_open_drain_pull_up_with_filter(
+                self,
+            ) -> $PXi<WiredAndPullUpWithFilter> {
+                unsafe {
+                    (*efm32::GPIO::ptr())
+                        .$modegroup
+                        .modify(|_, w| w.$mode().wiredandpullupfilter())
+                };
+                $PXi { _mode: PhantomData }
+            }
+
+            pub fn into_output_open_drain_drive(self) -> $PXi<WiredAndDrive> {
+                unsafe {
+                    (*efm32::GPIO::ptr())
+                        .$modegroup
+                        .modify(|_, w| w.$mode().wiredanddrive())
+                };
+                $PXi { _mode: PhantomData }
+            }
+
+            pub fn into_output_open_drain_drive_with_filter(self) -> $PXi<WiredAndDriveWithFilter> {
+                unsafe {
+                    (*efm32::GPIO::ptr())
+                        .$modegroup
+                        .modify(|_, w| w.$mode().wiredanddrivefilter())
+                };
+                $PXi { _mode: PhantomData }
+            }
+
+            pub fn into_output_open_drain_drive_pull_up(self) -> $PXi<WiredAndDrivePullUp> {
+                unsafe {
+                    (*efm32::GPIO::ptr())
+                        .$modegroup
+                        .modify(|_, w| w.$mode().wiredanddrivepullup())
+                };
+                $PXi { _mode: PhantomData }
+            }
+
+            pub fn into_output_open_drain_drive_pull_up_with_filter(
+                self,
+            ) -> $PXi<WiredAndDrivePullUpWithFilter> {
+                unsafe {
+                    (*efm32::GPIO::ptr())
+                        .$modegroup
+                        .modify(|_, w| w.$mode().wiredanddrivepullupfilter())
+                };
+                $PXi { _mode: PhantomData }
+            }
         }
-    }
+    };
 }
 
-gpio_pin!(A0, 0, mode0, pa_model, pa_doutset, pa_doutclr, pa_douttgl);
-gpio_pin!(B7, 7, mode7, pb_model, pb_doutset, pb_doutclr, pb_douttgl);
-gpio_pin!(B8, 0, mode8, pb_modeh, pb_doutset, pb_doutclr, pb_douttgl);
-gpio_pin!(B11, 3, mode11, pb_modeh, pb_doutset, pb_doutclr, pb_douttgl);
-gpio_pin!(B13, 5, mode13, pb_modeh, pb_doutset, pb_doutclr, pb_douttgl);
-gpio_pin!(B14, 6, mode14, pb_modeh, pb_doutset, pb_doutclr, pb_douttgl);
-gpio_pin!(C0, 0, mode0, pc_model, pc_doutset, pc_doutclr, pc_douttgl);
-gpio_pin!(C1, 1, mode1, pc_model, pc_doutset, pc_doutclr, pc_douttgl);
-gpio_pin!(C14, 6, mode14, pc_modeh, pc_doutset, pc_doutclr, pc_douttgl);
-gpio_pin!(C15, 7, mode15, pc_modeh, pc_doutset, pc_doutclr, pc_douttgl);
-gpio_pin!(E12, 4, mode12, pe_modeh, pe_doutset, pe_doutclr, pe_douttgl);
-gpio_pin!(E13, 5, mode13, pe_modeh, pe_doutset, pe_doutclr, pe_douttgl);
-gpio_pin!(F0, 0, mode0, pf_model, pf_doutset, pf_doutclr, pf_douttgl);
-gpio_pin!(F1, 1, mode1, pf_model, pf_doutset, pf_doutclr, pf_douttgl);
-gpio_pin!(F2, 2, mode2, pf_model, pf_doutset, pf_doutclr, pf_douttgl);
+gpio_pin!(A0, 0, mode0, pa_model, pa_doutset, pa_doutclr, pa_douttgl, pa_din);
+gpio_pin!(B7, 7, mode7, pb_model, pb_doutset, pb_doutclr, pb_douttgl, pb_din);
+gpio_pin!(B8, 0, mode8, pb_modeh, pb_doutset, pb_doutclr, pb_douttgl, pb_din);
+gpio_pin!(B11, 3, mode11, pb_modeh, pb_doutset, pb_doutclr, pb_douttgl, pb_din);
+gpio_pin!(B13, 5, mode13, pb_modeh, pb_doutset, pb_doutclr, pb_douttgl, pb_din);
+gpio_pin!(B14, 6, mode14, pb_modeh, pb_doutset, pb_doutclr, pb_douttgl, pb_din);
+gpio_pin!(C0, 0, mode0, pc_model, pc_doutset, pc_doutclr, pc_douttgl, pc_din);
+gpio_pin!(C1, 1, mode1, pc_model, pc_doutset, pc_doutclr, pc_douttgl, pc_din);
+gpio_pin!(C14, 6, mode14, pc_modeh, pc_doutset, pc_doutclr, pc_douttgl, pc_din);
+gpio_pin!(C15, 7, mode15, pc_modeh, pc_doutset, pc_doutclr, pc_douttgl, pc_din);
+gpio_pin!(E12, 4, mode12, pe_modeh, pe_doutset, pe_doutclr, pe_douttgl, pe_din);
+gpio_pin!(E13, 5, mode13, pe_modeh, pe_doutset, pe_doutclr, pe_douttgl, pe_din);
+gpio_pin!(F0, 0, mode0, pf_model, pf_doutset, pf_doutclr, pf_douttgl, pf_din);
+gpio_pin!(F1, 1, mode1, pf_model, pf_doutset, pf_doutclr, pf_douttgl, pe_din);
+gpio_pin!(F2, 2, mode2, pf_model, pf_doutset, pf_doutclr, pf_douttgl, pe_din);
 
 /// GPIO parts
 pub struct Parts {

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -25,7 +25,12 @@
 //!
 //! ```
 
+use core::marker::PhantomData;
 use crate::efm32;
+use crate::efm32::{CMU, GPIO};
+use embedded_hal::digital::{OutputPin, ToggleableOutputPin};
+
+pub trait OutputMode {}
 
 /// Disable Input/Output no pullup.
 pub struct Disabled;
@@ -68,6 +73,7 @@ pub type OpenSourcePullDown = WiredOrPullDown;
 /// Enable Input and Output in open-drain mode.
 pub struct WiredAnd;
 pub type OpenDrain = WiredAnd;
+impl OutputMode for WiredAnd {}
 
 /// Enable Input and Output in open-drain mode with glitch filter for input.
 pub struct WiredAndWithFilter;
@@ -103,537 +109,111 @@ pub type OpenDrainDrivePullUp = WiredAndDrivePullUp;
 pub struct WiredAndDrivePullUpWithFilter;
 pub type OpenDrainDrivePullUpWithFilter = WiredAndDrivePullUpWithFilter;
 
-/// GPIO pin handler.
-/// Currently it doesn't hold any data.
-pub struct GPIO;
 
-impl GPIO {
-    /// Create new GPIO device, this should `take` GPIO
-    /// device exclusively, but currently it doesn't.
-    pub fn new(cmu: &mut efm32::CMU) -> Self {
+/// Extension trait to split a GPIO peripheral in independent pins and registers
+pub trait GpioExt {
+    /// The to split the GPIO into
+    type Parts;
+
+    /// Splits the GPIO block into independent pins and registers
+    fn split(self, cmu: &mut CMU) -> Self::Parts;
+}
+
+macro_rules! gpio_pin { 
+    ($PXi:ident, $i:expr, $mode: ident, $modegroup: ident, $outset:ident, $outclr: ident, $outtgl: ident) => {
+        pub struct $PXi<MODE> {
+            _mode: PhantomData<MODE>,
+        }
+        
+        impl<MODE: OutputMode> OutputPin for $PXi<MODE> {
+            fn set_high(&mut self) {
+                // NOTE(unsafe) atomic write to a stateless register
+                unsafe { (*efm32::GPIO::ptr()).$outset.write(|w| w.bits(1 << $i)) };
+            }
+
+            fn set_low(&mut self) {
+                // NOTE(unsafe) atomic write to a stateless register
+               unsafe { (*efm32::GPIO::ptr()).$outclr.write(|w| w.bits(1 << $i)) };
+            }
+        }
+
+        impl<MODE: OutputMode> ToggleableOutputPin for $PXi<MODE> {
+            fn toggle(&mut self) {
+                unsafe { (*efm32::GPIO::ptr()).$outtgl.write(|w| w.bits(1 << $i)) };
+            }
+        }
+
+        impl<MODE> $PXi<MODE> {
+            pub fn into_open_drain(self) -> $PXi<OpenDrain> {
+                unsafe {
+                    (*efm32::GPIO::ptr())
+                        .$modegroup
+                        .modify(|_, w| w.$mode().wiredand())
+                };
+                $PXi { _mode: PhantomData }
+            }
+        }
+    }
+}
+
+gpio_pin!(A0, 0, mode0, pa_model, pa_doutset, pa_doutclr, pa_douttgl);
+gpio_pin!(B7, 7, mode7, pb_model, pb_doutset, pb_doutclr, pb_douttgl);
+gpio_pin!(B8, 0, mode8, pb_modeh, pb_doutset, pb_doutclr, pb_douttgl);
+gpio_pin!(B11, 3, mode11, pb_modeh, pb_doutset, pb_doutclr, pb_douttgl);
+gpio_pin!(B13, 5, mode13, pb_modeh, pb_doutset, pb_doutclr, pb_douttgl);
+gpio_pin!(B14, 6, mode14, pb_modeh, pb_doutset, pb_doutclr, pb_douttgl);
+gpio_pin!(C0, 0, mode0, pc_model, pc_doutset, pc_doutclr, pc_douttgl);
+gpio_pin!(C1, 1, mode1, pc_model, pc_doutset, pc_doutclr, pc_douttgl);
+gpio_pin!(C14, 6, mode14, pc_modeh, pc_doutset, pc_doutclr, pc_douttgl);
+gpio_pin!(C15, 7, mode15, pc_modeh, pc_doutset, pc_doutclr, pc_douttgl);
+gpio_pin!(E12, 4, mode12, pe_modeh, pe_doutset, pe_doutclr, pe_douttgl);
+gpio_pin!(E13, 5, mode13, pe_modeh, pe_doutset, pe_doutclr, pe_douttgl);
+gpio_pin!(F0, 0, mode0, pf_model, pf_doutset, pf_doutclr, pf_douttgl);
+gpio_pin!(F1, 1, mode1, pf_model, pf_doutset, pf_doutclr, pf_douttgl);
+gpio_pin!(F2, 2, mode2, pf_model, pf_doutset, pf_doutclr, pf_douttgl);
+
+/// GPIO parts
+pub struct Parts {
+    /// Pin
+    pub a0: A0<Disabled>,
+    pub b7: B7<Disabled>,
+    pub b8: B8<Disabled>,
+    pub b11: B11<Disabled>,
+    pub b13: B13<Disabled>,
+    pub b14: B14<Disabled>,
+    pub c0: C0<Disabled>,
+    pub c1: C1<Disabled>,
+    pub c14: C14<Disabled>,
+    pub c15: C15<Disabled>,
+    pub e12: E12<Disabled>,
+    pub e13: E13<Disabled>,
+    pub f0: F0<Disabled>,
+    pub f1: F1<Disabled>,
+    pub f2: F2<Disabled>,
+}
+
+impl GpioExt for GPIO {
+    type Parts = Parts;
+
+    fn split(self, cmu: &mut CMU) -> Self::Parts {
         cmu.hfperclken0.modify(|_, w| w.gpio().bit(true));
 
-        GPIO
+        Parts {
+            a0: A0 { _mode: PhantomData },
+            b7: B7 { _mode: PhantomData },
+            b8: B8 { _mode: PhantomData },
+            b11: B11 { _mode: PhantomData },
+            b13: B13 { _mode: PhantomData },
+            b14: B14 { _mode: PhantomData },
+            c0: C0 { _mode: PhantomData },
+            c1: C1 { _mode: PhantomData },
+            c14: C14 { _mode: PhantomData },
+            c15: C15 { _mode: PhantomData },
+            e12: E12 { _mode: PhantomData },
+            e13: E13 { _mode: PhantomData },
+            f0: F0 { _mode: PhantomData },
+            f1: F1 { _mode: PhantomData },
+            f2: F2 { _mode: PhantomData },
+        }
     }
-
-    /// Create new pin with specific mode.
-    /// For example:
-    /// ```no_run
-    /// let gpio = GPIO;
-    /// let mut a0 = gpio.split<A0<OpenDrain>>();
-    ///
-    /// a0.set_high();
-    /// ```
-    pub fn split<MODE: GPIOPinSplitter>(&self) -> MODE::GPIOPin {
-        MODE::split()
-    }
-}
-
-/// Traits to split GPIO into mode specific pin
-/// Available pins in tomu/efm32hg309f64 are set
-/// to implement this trait.
-pub trait GPIOPinSplitter {
-    type GPIOPin;
-
-    /// Actual split implementation for each pin
-    fn split() -> Self::GPIOPin;
-}
-
-macro_rules! gpio_pin_splitter {
-    ($pin_struct:ident,
-     $io_mode:ident,
-     $modegroup:ident,
-     $mode:ident,
-     $setter:ident) => {
-        impl GPIOPinSplitter for $pin_struct<$io_mode> {
-            type GPIOPin = $pin_struct<$io_mode>;
-
-            fn split() -> Self::GPIOPin {
-                unsafe {
-                    (*efm32::GPIO::ptr())
-                        .$modegroup
-                        .modify(|_, w| w.$mode().$setter())
-                };
-                $pin_struct { _m: PhantomData }
-            }
-        }
-    };
-
-    ($pin_struct:ident,
-     $io_mode:ident,
-     $modegroup:ident,
-     $mode:ident,
-     $setter:ident,
-     $shift:expr,
-     $outset:ident) => {
-        impl GPIOPinSplitter for $pin_struct<$io_mode> {
-            type GPIOPin = $pin_struct<$io_mode>;
-
-            fn split() -> Self::GPIOPin {
-                unsafe {
-                    (*efm32::GPIO::ptr())
-                        .$modegroup
-                        .modify(|_, w| w.$mode().$setter());
-                    (*efm32::GPIO::ptr()).$outset.write(|w| w.bits(1 << $shift));
-                };
-                $pin_struct { _m: PhantomData }
-            }
-        }
-    };
-}
-
-macro_rules! gpio_in_impl {
-    ($pin_struct:ident,
-     $io_mode:ident,
-     $in:ident,
-     $shift:expr) => {
-        impl InputPin for $pin_struct<$io_mode> {
-            fn is_high(&self) -> bool {
-                let pos = 1 << $shift;
-                unsafe { ((*efm32::GPIO::ptr()).$in.read().bits() & pos) == pos }
-            }
-
-            fn is_low(&self) -> bool {
-                !self.is_high()
-            }
-        }
-    };
-}
-
-macro_rules! gpio_out_impl {
-    ($pin_struct:ident,
-     $io_mode:ident,
-     $shift: expr,
-     $outset:ident,
-     $outclr:ident,
-     $outtgl:ident) => {
-        impl OutputPin for $pin_struct<$io_mode> {
-            fn set_low(&mut self) {
-                unsafe { (*efm32::GPIO::ptr()).$outclr.write(|w| w.bits(1 << $shift)) };
-            }
-
-            fn set_high(&mut self) {
-                unsafe { (*efm32::GPIO::ptr()).$outset.write(|w| w.bits(1 << $shift)) };
-            }
-        }
-
-        impl ToggleableOutputPin for $pin_struct<$io_mode> {
-            fn toggle(&mut self) {
-                unsafe { (*efm32::GPIO::ptr()).$outtgl.write(|w| w.bits(1 << $shift)) };
-            }
-        }
-    };
-}
-
-macro_rules! gpio {
-    ($pin_struct:ident,
-     $mode:ident,
-     $shift:expr,
-     $ctrl:ident,
-     $modegroup:ident,
-     $out:ident,
-     $outset:ident,
-     $outclr:ident,
-     $outtgl:ident,
-     $in:ident,
-     $lock:ident) => {
-        pub struct $pin_struct<Mode> {
-            _m: PhantomData<Mode>,
-        }
-
-        // Disabled pin variants
-        gpio_pin_splitter!($pin_struct, Disabled, $modegroup, $mode, disabled);
-        gpio_pin_splitter!(
-            $pin_struct,
-            DisabledPullUp,
-            $modegroup,
-            $mode,
-            disabled,
-            $shift,
-            $outset
-        );
-
-        // Input pin variants
-        gpio_pin_splitter!($pin_struct, Input, $modegroup, $mode, input);
-        gpio_pin_splitter!(
-            $pin_struct,
-            InputWithFilter,
-            $modegroup,
-            $mode,
-            input,
-            $shift,
-            $outset
-        );
-
-        gpio_pin_splitter!($pin_struct, InputPullDown, $modegroup, $mode, inputpull);
-        gpio_pin_splitter!(
-            $pin_struct,
-            InputPullUp,
-            $modegroup,
-            $mode,
-            inputpull,
-            $shift,
-            $outset
-        );
-
-        gpio_pin_splitter!(
-            $pin_struct,
-            InputPullDownWithFilter,
-            $modegroup,
-            $mode,
-            inputpullfilter
-        );
-        gpio_pin_splitter!(
-            $pin_struct,
-            InputPullUpWithFilter,
-            $modegroup,
-            $mode,
-            inputpullfilter,
-            $shift,
-            $outset
-        );
-
-        gpio_in_impl!($pin_struct, Input, $in, $shift);
-        gpio_in_impl!($pin_struct, InputWithFilter, $in, $shift);
-        gpio_in_impl!($pin_struct, InputPullDown, $in, $shift);
-        gpio_in_impl!($pin_struct, InputPullUp, $in, $shift);
-        gpio_in_impl!($pin_struct, InputPullDownWithFilter, $in, $shift);
-        gpio_in_impl!($pin_struct, InputPullUpWithFilter, $in, $shift);
-
-        // Output pin variants
-        gpio_pin_splitter!($pin_struct, PushPull, $modegroup, $mode, pushpull);
-        gpio_pin_splitter!($pin_struct, PushPullDrive, $modegroup, $mode, pushpulldrive);
-        gpio_pin_splitter!($pin_struct, WiredOr, $modegroup, $mode, wiredor);
-        gpio_pin_splitter!(
-            $pin_struct,
-            WiredOrPullDown,
-            $modegroup,
-            $mode,
-            wiredorpulldown
-        );
-        gpio_pin_splitter!($pin_struct, WiredAnd, $modegroup, $mode, wiredand);
-        gpio_pin_splitter!(
-            $pin_struct,
-            WiredAndWithFilter,
-            $modegroup,
-            $mode,
-            wiredandfilter
-        );
-        gpio_pin_splitter!(
-            $pin_struct,
-            WiredAndPullUp,
-            $modegroup,
-            $mode,
-            wiredandpullup
-        );
-        gpio_pin_splitter!(
-            $pin_struct,
-            WiredAndPullUpWithFilter,
-            $modegroup,
-            $mode,
-            wiredandpullupfilter
-        );
-        gpio_pin_splitter!($pin_struct, WiredAndDrive, $modegroup, $mode, wiredanddrive);
-        gpio_pin_splitter!(
-            $pin_struct,
-            WiredAndDriveWithFilter,
-            $modegroup,
-            $mode,
-            wiredanddrivefilter
-        );
-        gpio_pin_splitter!(
-            $pin_struct,
-            WiredAndDrivePullUp,
-            $modegroup,
-            $mode,
-            wiredanddrivepullup
-        );
-        gpio_pin_splitter!(
-            $pin_struct,
-            WiredAndDrivePullUpWithFilter,
-            $modegroup,
-            $mode,
-            wiredanddrivepullupfilter
-        );
-
-        gpio_out_impl!($pin_struct, PushPull, $shift, $outset, $outclr, $outtgl);
-        gpio_out_impl!(
-            $pin_struct,
-            PushPullDrive,
-            $shift,
-            $outset,
-            $outclr,
-            $outtgl
-        );
-        gpio_out_impl!($pin_struct, WiredOr, $shift, $outset, $outclr, $outtgl);
-        gpio_out_impl!(
-            $pin_struct,
-            WiredOrPullDown,
-            $shift,
-            $outset,
-            $outclr,
-            $outtgl
-        );
-        gpio_out_impl!($pin_struct, WiredAnd, $shift, $outset, $outclr, $outtgl);
-        gpio_out_impl!(
-            $pin_struct,
-            WiredAndWithFilter,
-            $shift,
-            $outset,
-            $outclr,
-            $outtgl
-        );
-        gpio_out_impl!(
-            $pin_struct,
-            WiredAndPullUp,
-            $shift,
-            $outset,
-            $outclr,
-            $outtgl
-        );
-        gpio_out_impl!(
-            $pin_struct,
-            WiredAndPullUpWithFilter,
-            $shift,
-            $outset,
-            $outclr,
-            $outtgl
-        );
-        gpio_out_impl!(
-            $pin_struct,
-            WiredAndDrive,
-            $shift,
-            $outset,
-            $outclr,
-            $outtgl
-        );
-        gpio_out_impl!(
-            $pin_struct,
-            WiredAndDriveWithFilter,
-            $shift,
-            $outset,
-            $outclr,
-            $outtgl
-        );
-        gpio_out_impl!(
-            $pin_struct,
-            WiredAndDrivePullUp,
-            $shift,
-            $outset,
-            $outclr,
-            $outtgl
-        );
-        gpio_out_impl!(
-            $pin_struct,
-            WiredAndDrivePullUpWithFilter,
-            $shift,
-            $outset,
-            $outclr,
-            $outtgl
-        );
-    };
-}
-
-/// Struct for each pin and its traits implementation live in this pin module.
-/// Only pin available in efm32hg309f64 listed here.
-pub mod pin {
-    use super::*;
-    use core::marker::PhantomData;
-    use embedded_hal::digital::{InputPin, OutputPin, ToggleableOutputPin};
-
-    gpio!(
-        A0,
-        mode0,
-        0,
-        pa_ctrl,
-        pa_model,
-        pa_dout,
-        pa_doutset,
-        pa_doutclr,
-        pa_douttgl,
-        pa_din,
-        pa_pinlockn
-    );
-    gpio!(
-        B7,
-        mode7,
-        7,
-        pb_ctrl,
-        pb_model,
-        pb_dout,
-        pb_doutset,
-        pb_doutclr,
-        pb_douttgl,
-        pb_din,
-        pb_pinlockn
-    );
-    gpio!(
-        B8,
-        mode8,
-        0,
-        pb_ctrl,
-        pb_modeh,
-        pb_dout,
-        pb_doutset,
-        pb_doutclr,
-        pb_douttgl,
-        pb_din,
-        pb_pinlockn
-    );
-    gpio!(
-        B11,
-        mode11,
-        3,
-        pb_ctrl,
-        pb_modeh,
-        pb_dout,
-        pb_doutset,
-        pb_doutclr,
-        pb_douttgl,
-        pb_din,
-        pb_pinlockn
-    );
-    gpio!(
-        B13,
-        mode13,
-        5,
-        pb_ctrl,
-        pb_modeh,
-        pb_dout,
-        pb_doutset,
-        pb_doutclr,
-        pb_douttgl,
-        pb_din,
-        pb_pinlockn
-    );
-    gpio!(
-        B14,
-        mode14,
-        6,
-        pb_ctrl,
-        pb_modeh,
-        pb_dout,
-        pb_doutset,
-        pb_doutclr,
-        pb_douttgl,
-        pb_din,
-        pb_pinlockn
-    );
-    gpio!(
-        C0,
-        mode0,
-        0,
-        pc_ctrl,
-        pc_model,
-        pc_dout,
-        pc_doutset,
-        pc_doutclr,
-        pc_douttgl,
-        pc_din,
-        pc_pinlockn
-    );
-    gpio!(
-        C1,
-        mode1,
-        1,
-        pc_ctrl,
-        pc_model,
-        pc_dout,
-        pc_doutset,
-        pc_doutclr,
-        pc_douttgl,
-        pc_din,
-        pc_pinlockn
-    );
-    gpio!(
-        C14,
-        mode14,
-        6,
-        pc_ctrl,
-        pc_modeh,
-        pc_dout,
-        pc_doutset,
-        pc_doutclr,
-        pc_douttgl,
-        pc_din,
-        pc_pinlockn
-    );
-    gpio!(
-        C15,
-        mode15,
-        7,
-        pc_ctrl,
-        pc_modeh,
-        pc_dout,
-        pc_doutset,
-        pc_doutclr,
-        pc_douttgl,
-        pc_din,
-        pc_pinlockn
-    );
-    gpio!(
-        E12,
-        mode12,
-        4,
-        pe_ctrl,
-        pe_modeh,
-        pe_dout,
-        pe_doutset,
-        pe_doutclr,
-        pe_douttgl,
-        pe_din,
-        pe_pinlockn
-    );
-    gpio!(
-        E13,
-        mode13,
-        5,
-        pe_ctrl,
-        pe_modeh,
-        pe_dout,
-        pe_doutset,
-        pe_doutclr,
-        pe_douttgl,
-        pe_din,
-        pe_pinlockn
-    );
-    gpio!(
-        F0,
-        mode0,
-        0,
-        pf_ctrl,
-        pf_model,
-        pf_dout,
-        pf_doutset,
-        pf_doutclr,
-        pf_douttgl,
-        pf_din,
-        pf_pinlockn
-    );
-    gpio!(
-        F1,
-        mode1,
-        1,
-        pf_ctrl,
-        pf_model,
-        pf_dout,
-        pf_doutset,
-        pf_doutclr,
-        pf_douttgl,
-        pf_din,
-        pf_pinlockn
-    );
-    gpio!(
-        F2,
-        mode2,
-        2,
-        pf_ctrl,
-        pf_model,
-        pf_dout,
-        pf_doutset,
-        pf_doutclr,
-        pf_douttgl,
-        pf_din,
-        pf_pinlockn
-    );
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,5 +15,12 @@ pub mod gpio;
 pub mod uart;
 pub mod usb;
 
+pub mod prelude {
+    pub use embedded_hal::prelude::*;
+
+    pub use crate::gpio::GpioExt;
+    // pub use crate::led::LedTrait;
+}
+
 #[cfg(feature = "toboot-custom-config")]
 pub use tomu_hal_macros::toboot_config;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,11 +7,11 @@ pub use crate::efm32::interrupt;
 
 pub mod toboot;
 
-pub mod peripherals;
+// pub mod peripherals;
 
-pub mod capacitive;
+// pub mod capacitive;
 pub mod gpio;
-pub mod led;
+// pub mod led;
 pub mod uart;
 pub mod usb;
 


### PR DESCRIPTION
regarding #15 

Im not great at macros, so a friend and I took a shot at your gpio implementation and it turned into a rewrite which may or may not be necessary, but the goal we achieved was to get to a high level api like others Ive seen elsewhere of 
```
        let gpio = p.GPIO.split();
        let red = gpio.a0.into_push_pull_output();
```
Though I still feel like were mixing hal and bsp.  We should implement all the other pins (which probably has us making more macros like you had) and then in the bsp restricting down to this subset of pins. 

What do you think? Im also happy to use your implementation with fixes instead. Just trying to get a clean split function directly on the GPIO struct which I think is common