### PR TITLE
Add example to try configuring capsense (touch) with raw PAC access

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,8 @@ compiletest_rs = "0.3.17"
 [features]
 toboot-custom-config = [ "tomu-macros" ]
 unproven = [ "embedded-hal/unproven", "efm32-hal/unproven" ]
+rt = [ ]
+default = [ "rt" ]
 
 [[example]]
 name = "toggle_blink"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ cast = { version = "0.2.2", default-features = false }
 [dependencies.efm32]
 git = "https://github.com/em32-rs/efm32hg-pac"
 package = "efm32hg-pac"
-features = [ "rt" ]
 
 [dependencies.efm32-hal]
 git = "https://github.com/fudanchii/efm32hg-hal"
@@ -33,7 +32,7 @@ compiletest_rs = "0.3.17"
 [features]
 toboot-custom-config = [ "tomu-macros" ]
 unproven = [ "embedded-hal/unproven", "efm32-hal/unproven" ]
-rt = [ ]
+rt = [ "efm32/rt" ]
 default = [ "rt" ]
 
 [[example]]

--- a/examples/pac_capsense.rs
+++ b/examples/pac_capsense.rs
@@ -5,12 +5,12 @@
 ///
 /// This is an example on how to configure touch sense (capsense) in
 /// efm32hg309 (imtomu) board. Capsense enabled by configuring ACMP0's
-/// negative signal in `capsense` mode, and routes the generated pulse
+/// negative signal in `capsense` mode, and route the generated pulse
 /// to TIMER0 via PRS channel.
 ///
-/// Another timer, TIMER1, acted as timekeeper and record the puls counted by
-/// TIMER0, and when ACMP's ch0 pad (GPIO PC0) sensing finger touch, the pulse
-/// periode will be lower and so resulting in smaller counter in TIMER0.
+/// Another timer, TIMER1, acted as timekeeper and record the pulse counted by
+/// TIMER0, and when ACMP0's ch0 pad (GPIO PC0) sensing finger touch, the pulse
+/// periode will be slower and so resulting in smaller counter in TIMER0.
 ///
 /// In this example we normalize the counter and use it as a blink period.
 /// The green led will blink faster when the capsense is touched.

--- a/examples/pac_capsense.rs
+++ b/examples/pac_capsense.rs
@@ -3,27 +3,104 @@
 
 extern crate panic_halt;
 
-use core::cell::Cell;
+use core::ops::DerefMut;
+use core::cell::RefCell;
 
 use cortex_m_rt::entry;
 use cortex_m::{asm, interrupt as intr, interrupt::Mutex};
 
-use tomu::{interrupt, Tomu};
+use efm32_hal::gpio::*;
+use tomu::{interrupt, Tomu, prelude::*};
 
-static TIMER1READY: Mutex<Cell<bool>> = Mutex::new(Cell::new(false));
+static _ACMP0: Mutex<RefCell<Option<efm32::ACMP0>>> = Mutex::new(RefCell::new(None));
+static _TIMER0: Mutex<RefCell<Option<efm32::TIMER0>>> = Mutex::new(RefCell::new(None));
+static _TIMER1: Mutex<RefCell<Option<efm32::TIMER1>>> = Mutex::new(RefCell::new(None));
+static GREENLED: Mutex<RefCell<Option<led::LED<pins::PA0<Output<OpenDrain<Normal, PullUp>>>>>>> = Mutex::new(RefCell::new(None));
 
 #[entry]
 fn main() -> ! {
     let tomu = Tomu::take().unwrap();
-    
-    tomu.CMU.hfperclken0.write(|w|
-        w
-            .acmp0().set_bit()
-            .timer0().set_bit()
-            .timer1().set_bit()
-            .prs().set_bit()
-    );
 
+    clock_setup(&tomu);
+
+    acmp0_setup(&tomu);
+
+    timer_setup(&tomu);
+
+    // constrain CMU and split into device clocks
+    // so we can enable gpio with its owned clock
+    let clk_mgmt = tomu.CMU.constrain().split();
+    let gpio = tomu.GPIO.split(clk_mgmt.gpio).pins();
+
+    // create tomu's led instance from gpio pin
+    let leds = led::LEDs::new(gpio.pa0.into(), gpio.pb7.into());
+
+    let mut red = leds.red;
+    let green = leds.green;
+
+    red.off();
+
+    efm32::NVIC::unpend(interrupt::TIMER1);
+    tomu.NVIC.enable(interrupt::TIMER1);
+
+    let acmp0 = tomu.ACMP0;
+    let timer0 = tomu.TIMER0;
+    let timer1 = tomu.TIMER1;
+    intr::free(|lock| {
+        _ACMP0.borrow(lock).replace(Some(acmp0));
+        _TIMER0.borrow(lock).replace(Some(timer0));
+        _TIMER1.borrow(lock).replace(Some(timer1));
+        GREENLED.borrow(lock).replace(Some(green));
+    });
+
+    loop { asm::wfi() }
+}
+
+#[interrupt]
+fn TIMER1() {
+    let _ = measure_stop();
+
+    intr::free(|lock| if let &mut Some(ref mut green) = GREENLED.borrow(lock).borrow_mut().deref_mut() {
+        green.toggle();
+    });
+
+    measure_start();
+}
+
+fn measure_start() {
+    intr::free(|lock| if let (&mut Some(ref mut timer0), &mut Some(ref mut timer1)) = (
+            _TIMER0.borrow(lock).borrow_mut().deref_mut(),
+            _TIMER1.borrow(lock).borrow_mut().deref_mut(),
+    ) {
+        timer0.cnt.write(|w| unsafe { w.cnt().bits(0u16) });
+        timer1.cnt.write(|w| unsafe { w.cnt().bits(0u16) });
+        timer0.cmd.write(|w| w.start().set_bit());
+        timer1.cmd.write(|w| w.start().set_bit());
+    });
+}
+
+fn measure_stop() -> u16 {
+    intr::free(|lock| if let (&mut Some(ref mut timer0), &mut Some(ref mut timer1)) = (
+            _TIMER0.borrow(lock).borrow_mut().deref_mut(),
+            _TIMER1.borrow(lock).borrow_mut().deref_mut(),
+    ) {
+        timer0.cmd.write(|w| w.stop().set_bit());
+        timer1.cmd.write(|w| w.stop().set_bit());
+        timer1.ifc.write(|w| w.of().set_bit());
+        timer0.cnt.read().cnt().bits()
+    } else { 0 })
+}
+
+fn clock_setup(tomu: &Tomu) {
+    tomu.CMU.hfperclken0.write(|w| w
+        .acmp0().set_bit()
+        .timer0().set_bit()
+        .timer1().set_bit()
+        .prs().set_bit()
+    );
+}
+
+fn acmp0_setup(tomu: &Tomu) {
     tomu.ACMP0.ctrl.write(|w| unsafe {
         w
             .fullbias().clear_bit()
@@ -53,22 +130,22 @@ fn main() -> ! {
     while !tomu.ACMP0.status.read().acmpact().bit_is_set() {
         asm::nop();
     }
+}
 
-    tomu.TIMER0.ctrl.write(|w|
-        w
-            .presc().div1024()
-            .clksel().cc1()
+fn timer_setup(tomu: &Tomu) {
+    tomu.TIMER0.ctrl.write(|w| w
+        .presc().div1024()
+        .clksel().cc1()
     );
 
     tomu.TIMER0.top.write(|w| unsafe { w.bits(0xffffu32) });
 
-    tomu.TIMER0.cc1_ctrl.write(|w|
-        w
-            .mode().inputcapture()
-            .prssel().prsch0()
-            .insel().set_bit()
-            .icevctrl().rising()
-            .icedge().both()
+    tomu.TIMER0.cc1_ctrl.write(|w| w
+        .mode().inputcapture()
+        .prssel().prsch0()
+        .insel().set_bit()
+        .icevctrl().rising()
+        .icedge().both()
     );
 
     tomu.PRS.ch0_ctrl.write(|w| unsafe {
@@ -78,80 +155,8 @@ fn main() -> ! {
             .sigsel().bits(0u8)
     });
 
-    tomu.TIMER1.ctrl.write(|w| w.presc().div1024() );
-    tomu.TIMER1.top.write(|w| unsafe { w.bits(40 * 21u32) });
+    tomu.TIMER1.ctrl.write(|w| w.presc().div1024());
+    tomu.TIMER1.top.write(|w| unsafe { w.top().bits(20508u16) });
     tomu.TIMER1.ien.write(|w| w.of().set_bit() );
     tomu.TIMER1.cnt.write(|w| unsafe { w.cnt().bits(0u16) });
-
-    let mut ch: usize = 0;
-    let mut touch = 0;
-    let mut present = 0;
-    let mut since_last_touch = 0;
-    let mut count_max: [u16; 2] = [0, 0];
-
-    loop {
-        let ready = intr::free(|cs| TIMER1READY.borrow(cs).get());
-
-        if !ready {
-            asm::wfi();
-            continue;
-        }
-
-        let count = measure_stop(&tomu);
-
-        let threshold = count_max[ch] - count_max[ch] / 2;
-        if count > 0 && count < threshold.into() {
-            touch |= 1 << ch;
-        } else {
-            touch &= !(1 << ch);
-        }
-
-        if count > threshold.into() {
-            count_max[ch] = (count_max[ch] + count as u16) / 2;
-        }
-
-        if present > 0 {
-            present -= 1;
-        }
-
-        if touch > 0 {
-            if since_last_touch > 10 {
-                if present > 0 {
-                    present = 0;
-                } else {
-                    present = 500;
-                }
-            }
-            since_last_touch = 0;
-        } else {
-            since_last_touch += 1;
-        }
-
-        if since_last_touch > 1000 {
-            since_last_touch = 1000;
-        }
-
-        ch ^= 1;
-        measure_start(ch as u8, &tomu);
-    }
-}
-
-fn measure_start(ch: u8, tomu: &Tomu) {
-    tomu.ACMP0.inputsel.modify(|_, w| w.possel().bits(ch));
-    tomu.TIMER0.cnt.write(|w| unsafe { w.cnt().bits(0u16) });
-    tomu.TIMER1.cnt.write(|w| unsafe { w.cnt().bits(0u16) });
-    tomu.TIMER0.cmd.write(|w| w.start().set_bit());
-    tomu.TIMER1.cmd.write(|w| w.start().set_bit());
-}
-
-fn measure_stop(tomu: &Tomu) -> u32 {
-    tomu.TIMER0.cmd.write(|w| w.stop().set_bit());
-    tomu.TIMER1.cmd.write(|w| w.stop().set_bit());
-    tomu.TIMER1.ifc.write(|w| w.of().set_bit());
-    tomu.TIMER0.cnt.read().bits()
-}
-
-#[interrupt]
-fn TIMER1() {
-    intr::free(|cs| TIMER1READY.borrow(cs).set(true));
 }

--- a/examples/pac_capsense.rs
+++ b/examples/pac_capsense.rs
@@ -1,0 +1,83 @@
+#![no_std]
+#![no_main]
+
+extern crate panic_halt;
+
+use cortex_m_rt::entry;
+use cortex_m::asm;
+
+use tomu::Tomu;
+
+#[entry]
+fn main() -> ! {
+    let tomu = Tomu::take().unwrap();
+    
+    tomu.CMU.hfperclken0.write(|w|
+        w
+            .acmp0().set_bit()
+            .timer0().set_bit()
+            .timer1().set_bit()
+            .prs().set_bit()
+    );
+
+    tomu.ACMP0.ctrl.write(|w| unsafe {
+        w
+            .fullbias().clear_bit()
+            .halfbias().clear_bit()
+            .biasprog().bits(7u8)
+            .warmtime()._512cycles()
+            .hystsel().hyst5()
+    });
+
+    tomu.ACMP0.inputsel.write(|w| unsafe {
+        w
+            .csressel().res3()
+            .csresen().set_bit()
+            .lpref().clear_bit()
+            .vddlevel().bits(0x3du8)
+            .negsel().capsense()
+    });
+
+    tomu.ACMP0.ctrl.modify(|_, w|
+        w.en().set_bit()
+    );
+
+    tomu.ACMP0.inputsel.modify(|_, w|
+        w.possel().ch0()
+    );
+
+    while !tomu.ACMP0.status.read().acmpact().bit_is_set() {
+        asm::nop();
+    }
+
+    tomu.TIMER0.ctrl.write(|w|
+        w
+            .presc().div1024()
+            .clksel().cc1()
+    );
+
+    tomu.TIMER0.top.write(|w| unsafe { w.bits(0xffffu32) });
+
+    tomu.TIMER0.cc1_ctrl.write(|w|
+        w
+            .mode().inputcapture()
+            .prssel().prsch0()
+            .insel().set_bit()
+            .icevctrl().rising()
+            .icedge().both()
+    );
+
+    tomu.PRS.ch0_ctrl.write(|w| unsafe {
+        w
+            .edsel().posedge()
+            .sourcesel().acmp0()
+            .sigsel().bits(0u8)
+    });
+
+    tomu.TIMER1.ctrl.write(|w| w.presc().div1024() );
+    tomu.TIMER1.top.write(|w| unsafe { w.bits(40 * 21u32) });
+    tomu.TIMER1.ien.write(|w| w.of().set_bit() );
+    tomu.TIMER1.cnt.write(|w| unsafe { w.cnt().bits(0u16) });
+
+    loop { asm::nop(); }
+}

--- a/src/led.rs
+++ b/src/led.rs
@@ -25,6 +25,9 @@ pub trait LedTrait {
     fn toggle(&mut self);
 }
 
+pub type GreenLED = LED<PA0<Output<OpenDrain<Normal, PullUp>>>>;
+pub type RedLED = LED<PB7<Output<OpenDrain<Normal, PullUp>>>>;
+
 /// LED struct stores all leds available
 /// in tomu board.
 /// It owns all the leds, but access can be moved per led.


### PR DESCRIPTION
translated partially from [chopstx csn driver](https://github.com/im-tomu/chopstx/blob/efm32/u2f/csn.c)

Example for configuring capsense with efm32's peripheral reflect system.

~still in progress~