### PR TITLE
examples: get rid of all extern-crate syntax

### DIFF
--- a/examples/blink.rs
+++ b/examples/blink.rs
@@ -1,10 +1,8 @@
 #![no_std]
 #![no_main]
 
-extern crate panic_halt;
-
 use cortex_m_rt::entry;
-
+use panic_halt as _;
 use tomu::{prelude::*, Tomu};
 
 #[entry]

--- a/examples/toboot_config.rs
+++ b/examples/toboot_config.rs
@@ -1,7 +1,6 @@
 #![no_std]
 #![no_main]
 
-extern crate panic_halt;
 
 // For non-examples (i.e. an actual crate)
 // tomu_macros don't need to be explicitly
@@ -10,7 +9,7 @@ extern crate panic_halt;
 use tomu_macros::toboot_config;
 
 use cortex_m_rt::entry;
-
+use panic_halt as _;
 use tomu::{prelude::*, Tomu};
 
 // this will cause tomu to always enter user application,

--- a/examples/toggle_blink.rs
+++ b/examples/toggle_blink.rs
@@ -1,10 +1,8 @@
 #![no_std]
 #![no_main]
 
-extern crate panic_halt;
-
 use cortex_m_rt::entry;
-
+use panic_halt as _;
 use tomu::{prelude::*, Tomu};
 
 #[entry]


### PR DESCRIPTION
This contains a minor update to all examples to get rid of "extern crate"
syntax.