### PR TITLE
Add DEVINFO from the latest PAC changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ features = [ "chip-efm32hg" ]
 # We don't have direct dependencies to this,
 # but will need this to build examples
 [dev-dependencies]
-cortex-m-rt = "0.6.10"
+cortex-m-rt = "0.6.11"
 panic-halt = "0.2.0"
 tomu-macros = { path = "macros" }
 

--- a/examples/devinfo_check.rs
+++ b/examples/devinfo_check.rs
@@ -27,7 +27,7 @@ fn main() -> ! {
 
     tomu.watchdog.disable();
 
-    let temp = tomu.DEVINFO.cal.read().temp().bits();
+    let temp = tomu.DEVINFO.cal.read().temp();
     let flash_size = tomu.DEVINFO.msize.read().flash();
     let ram_size = tomu.DEVINFO.msize.read().sram();
 

--- a/examples/devinfo_check.rs
+++ b/examples/devinfo_check.rs
@@ -1,0 +1,50 @@
+#![no_std]
+#![no_main]
+
+use cortex_m_rt::entry;
+use panic_halt as _;
+use tomu::{prelude::*, Tomu};
+
+#[entry]
+fn main() -> ! {
+    let mut tomu = Tomu::take().unwrap();
+
+    // constrain CMU and split into device clocks
+    // so we can enable gpio with its owned clock
+    let clk_mgmt = tomu.CMU.constrain().split();
+    let gpio = tomu.GPIO.split(clk_mgmt.gpio).pins();
+
+    // create tomu's led instance from gpio pin
+    let leds = led::LEDs::new(gpio.pa0.into(), gpio.pb7.into());
+
+    let mut red = leds.red;
+    let mut green = leds.green;
+
+    red.off();
+    green.off();
+
+    let mut delay = systick::SystickDelay::new(tomu.SYST.constrain(), clk_mgmt.hfcoreclk);
+
+    tomu.watchdog.disable();
+
+    let temp = tomu.DEVINFO.cal.read().temp().bits();
+    let flash_size = tomu.DEVINFO.msize.read().flash();
+    let ram_size = tomu.DEVINFO.msize.read().sram();
+
+    let correct = temp == 25u8 && flash_size == 64u16 && ram_size == 8u16;
+
+    loop {
+        if correct {
+            green.on();
+            delay.delay_ms(250u16);
+            green.off();
+            delay.delay_ms(250u16);
+            continue;
+        }
+
+        red.on();
+        delay.delay_ms(250u16);
+        red.off();
+        delay.delay_ms(250u16);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,6 @@ pub mod prelude {
 /// Holds all available tomu peripherals
 #[allow(non_snake_case)]
 pub struct Tomu {
-    #[allow(dead_code)]
     pub watchdog: efm32_hal::watchdog::Watchdog,
 
     /// Core peripheral: Cache and branch predictor maintenance operations
@@ -81,6 +80,9 @@ pub struct Tomu {
 
     /// efm32 peripheral: CMU
     pub CMU: efm32::CMU,
+
+    /// efm32 peripheral: Device Info read only pages
+    pub DEVINFO: efm32::DEVINFO,
 
     /// efm32 peripheral: DMA
     pub DMA: efm32::DMA,
@@ -173,6 +175,7 @@ impl Tomu {
             ADC0: p.ADC0,
             AES: p.AES,
             CMU: p.CMU,
+            DEVINFO: p.DEVINFO,
             DMA: p.DMA,
             EMU: p.EMU,
             GPIO: p.GPIO,


### PR DESCRIPTION
Includes example code to check if ref temp, flash size, and ram size info is correct.
The example code will blink green if the value is correct.